### PR TITLE
fix: Add another mounted check

### DIFF
--- a/lib/code_block.dart
+++ b/lib/code_block.dart
@@ -59,7 +59,7 @@ class _CodeBlockState extends State<CodeBlock> {
           }
           if (mounted) {
             WidgetsBinding.instance.addPostFrameCallback((_) {
-              setState(() => language = lang);
+              if (mounted) setState(() => language = lang);
             });
           }
         });


### PR DESCRIPTION
We've got this in the app:

11-16 13:08:12.526 30218 30261 E flutter : [ERROR:flutter/lib/ui/ui_dart_state.cc(177)] Unhandled Exception: NoSuchMethodError: The method 'markNeedsBuild' was called on null.
11-16 13:08:12.526 30218 30261 E flutter : Receiver: null
11-16 13:08:12.526 30218 30261 E flutter : Tried calling: markNeedsBuild()
11-16 13:08:12.526 30218 30261 E flutter : #0      State.setState (package:flutter/src/widgets/framework.dart:1264)
11-16 13:08:12.526 30218 30261 E flutter : #1      _CodeBlockState.initState.<anonymous closure>.<anonymous closure> (package:flutter_matrix_html/code_block.dart:62)
11-16 13:08:12.526 30218 30261 E flutter : #2      SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1117)
11-16 13:08:12.526 30218 30261 E flutter : #3      SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1063)
11-16 13:08:12.526 30218 30261 E flutter : #4      SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:971)
11-16 13:08:12.526 30218 30261 E flutter : #5      _rootRun (dart:async/zone.dart:1190)
11-16 13:08:12.526 30218 30261 E flutter : #6      _CustomZone.run (dart:async/zone.dart:1093)
11-16 13:08:12.526 30218 30261 E flutter : #7      _CustomZone.runGuarded (dart:async/zone.dart:997)
11-16 13:08:12.526 30218 30261 E flutter : #8      _invoke (dart:ui/hooks.dart:251)
11-16 13:08:12.526 30218 30261 E flutter : #9      _drawFrame (dart:ui/hooks.dart:209)


So I guess we need a mounted check there too.