### PR TITLE
improve/add pill builder for customization

### DIFF
--- a/lib/flutter_html.dart
+++ b/lib/flutter_html.dart
@@ -32,6 +32,7 @@ class Html extends StatelessWidget {
     this.getCodeLanguage,
     this.setCodeLanguage,
     this.inlineSpanEnd,
+    this.pillBuilder,
   }) : super(key: key);
 
   final String data;
@@ -57,6 +58,7 @@ class Html extends StatelessWidget {
   /// Setting and getting code langauge cache
   final SetCodeLanguage? setCodeLanguage;
   final GetCodeLanguage? getCodeLanguage;
+  final PillBuilder? pillBuilder;
 
   final InlineSpan? inlineSpanEnd;
 
@@ -89,6 +91,7 @@ class Html extends StatelessWidget {
           setCodeLanguage: setCodeLanguage,
           getCodeLanguage: getCodeLanguage,
           inlineSpanEnd: inlineSpanEnd,
+          pillBuilder: pillBuilder,
         ),
       ),
     );

--- a/lib/text_parser.dart
+++ b/lib/text_parser.dart
@@ -24,6 +24,7 @@ typedef OnPillTap = void Function(String identifier);
 typedef GetMxcUrl = String Function(String mxc, double? width, double? height,
     {bool? animated});
 typedef GetPillInfo = Future<Map<String, dynamic>> Function(String identifier);
+typedef PillBuilder = Widget? Function(String identifier, String url, OnPillTap? onTap, GetMxcUrl? getMxcUrl);
 
 const OFFSET_TAGS_FONT_SIZE_FACTOR =
     0.7; //The ratio of the parent font for each of the offset tags: sup or sub
@@ -105,6 +106,7 @@ class TextParser extends StatelessWidget {
     this.setCodeLanguage,
     this.getCodeLanguage,
     this.inlineSpanEnd,
+    this.pillBuilder,
   });
 
   final double indentSize = 10.0;
@@ -127,6 +129,7 @@ class TextParser extends StatelessWidget {
   final SetCodeLanguage? setCodeLanguage;
   final GetCodeLanguage? getCodeLanguage;
   final InlineSpan? inlineSpanEnd;
+  final PillBuilder? pillBuilder;
 
   TextSpan _parseTextNode(
       BuildContext context, ParseContext parseContext, dom.Text node) {
@@ -461,7 +464,7 @@ class TextParser extends StatelessWidget {
             if (isPill) {
               return WidgetSpan(
                 alignment: PlaceholderAlignment.middle,
-                child: Pill(
+                child: pillBuilder?.call(identifier, url, onPillTap, getMxcUrl) ?? Pill(
                   identifier: identifier,
                   url: url,
                   future: getPillInfo?.call(url),


### PR DESCRIPTION
Hello @Sorunome, I would like to make a change to your package because the current Pill widget uses FutureBuilder, which causes the message to be rebuilt multiple times and results in a blink effect. My solution is to cache the `PillInfo` outside of the widget and avoid using FutureBuilder internally. Additionally, I believe that the current customization options for the Pill widget are quite limited.

- Before PillBuilder:

https://github.com/Sorunome/flutter_matrix_html/assets/43041967/41bd1af3-2d3d-432e-a8d3-8dd166101d0e

- After have PillBuilder:

https://github.com/Sorunome/flutter_matrix_html/assets/43041967/b06f10e3-be81-46fb-b47c-64b798eb57a0

