### PR TITLE
fix: prevent inlineSpanEnd from getting rich text styles

### DIFF
--- a/lib/text_parser.dart
+++ b/lib/text_parser.dart
@@ -998,22 +998,23 @@ class TextParser extends StatelessWidget {
     final childRichText = richText.child;
     if (childRichText is TextSpan) {
       return CleanRichText(
-        TextSpan(
-          text: childRichText.text,
-          style: childRichText.style,
-          recognizer: childRichText.recognizer,
-          mouseCursor: childRichText.mouseCursor,
-          onEnter: childRichText.onEnter,
-          onExit: childRichText.onExit,
-          semanticsLabel: childRichText.semanticsLabel,
-          locale: childRichText.locale,
-          spellOut: childRichText.spellOut,
-          children: [
-            if (childRichText.children != null)
-              ...childRichText.children!,
-            inlineSpan
-          ]
-        ),
+        TextSpan(children: [
+          TextSpan(
+            text: childRichText.text,
+            style: childRichText.style,
+            recognizer: childRichText.recognizer,
+            mouseCursor: childRichText.mouseCursor,
+            onEnter: childRichText.onEnter,
+            onExit: childRichText.onExit,
+            semanticsLabel: childRichText.semanticsLabel,
+            locale: childRichText.locale,
+            spellOut: childRichText.spellOut,
+            children: [
+              if (childRichText.children != null) ...childRichText.children!,
+            ],
+          ),
+          inlineSpan
+        ]),
         maxLines: richText.maxLines,
         textAlign: richText.textAlign,
       );
@@ -1022,8 +1023,8 @@ class TextParser extends StatelessWidget {
         TextSpan(
           children: [
             childRichText,
-            inlineSpan
-          ]
+            inlineSpan,
+          ],
         ),
         maxLines: richText.maxLines,
         textAlign: richText.textAlign,


### PR DESCRIPTION
Because we added inlineSpanEnd to make a padding at the end of a message, it was getting styles such as code block styles. 
That lead to weird displays such as 
![image](https://github.com/Sorunome/flutter_matrix_html/assets/48354990/67512ed3-a56e-46a8-b603-7ecc7a4b9e98)

Now, inlineSpanEnd will just act as a gap
![image](https://github.com/Sorunome/flutter_matrix_html/assets/48354990/c4d0930e-119c-4a9b-8997-1b212b20c355)
